### PR TITLE
Refactor: introduce PersonBuilder for extensible Person updates

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -15,6 +15,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonBuilder;
 
 /**
  * Edits the appointment start date-time of an existing person in the address book.
@@ -57,9 +58,9 @@ public class EditApptCommand extends EditCommand {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
-                personToEdit.getAddress(), personToEdit.getTags(), personToEdit.getParentName(),
-                Optional.of(appointmentStart));
+        Person editedPerson = new PersonBuilder(personToEdit)
+                .withAppointmentStart(Optional.of(appointmentStart))
+                .build();
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/EditParentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditParentCommand.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.ParentName;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonBuilder;
 
 /**
  * Edits the parent name of an existing person in the address book.
@@ -55,14 +56,9 @@ public class EditParentCommand extends EditCommand {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(
-                personToEdit.getName(),
-                personToEdit.getPhone(),
-                personToEdit.getEmail(),
-                personToEdit.getAddress(),
-                personToEdit.getTags(),
-                Optional.of(parentName),
-                personToEdit.getAppointmentStart());
+        Person editedPerson = new PersonBuilder(personToEdit)
+                .withParentName(Optional.of(parentName))
+                .build();
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/EditTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTagCommand.java
@@ -4,10 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -16,6 +14,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonBuilder;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -37,23 +36,24 @@ public class EditTagCommand extends EditCommand {
     public static final String MESSAGE_EDIT_TAG_SUCCESS = "Edited Tags for Person: %1$s";
 
     private final Index index;
-    private final EditTagDescriptor editTagDescriptor;
+    private final Set<Tag> tags;
 
     /**
      * @param index of the person in the filtered person list to edit
-     * @param editTagDescriptor details to edit the tags with
+     * @param tags new tag set (empty set means clear all tags)
      */
-    public EditTagCommand(Index index, EditTagDescriptor editTagDescriptor) {
+    public EditTagCommand(Index index, Set<Tag> tags) {
         requireNonNull(index);
-        requireNonNull(editTagDescriptor);
+        requireNonNull(tags);
 
         this.index = index;
-        this.editTagDescriptor = new EditTagDescriptor(editTagDescriptor);
+        this.tags = new HashSet<>(tags);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -61,27 +61,16 @@ public class EditTagCommand extends EditCommand {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = createEditedPerson(personToEdit, editTagDescriptor);
+
+        Person editedPerson = new PersonBuilder(personToEdit)
+                .withTags(tags)
+                .build();
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_TAG_SUCCESS, Messages.format(editedPerson)));
-    }
 
-    /**
-     * Creates and returns a {@code Person} with updated tags.
-     */
-    private static Person createEditedPerson(Person personToEdit, EditTagDescriptor editTagDescriptor) {
-        assert personToEdit != null;
-
-        Set<Tag> updatedTags = editTagDescriptor.getTags();
-
-        return new Person(
-                personToEdit.getName(),
-                personToEdit.getPhone(),
-                personToEdit.getEmail(),
-                personToEdit.getAddress(),
-                updatedTags);
+        return new CommandResult(
+                String.format(MESSAGE_EDIT_TAG_SUCCESS, Messages.format(editedPerson)));
     }
 
     @Override
@@ -96,66 +85,14 @@ public class EditTagCommand extends EditCommand {
 
         EditTagCommand otherCommand = (EditTagCommand) other;
         return index.equals(otherCommand.index)
-                && editTagDescriptor.equals(otherCommand.editTagDescriptor);
+                && tags.equals(otherCommand.tags);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("index", index)
-                .add("editTagDescriptor", editTagDescriptor)
+                .add("tags", tags)
                 .toString();
-    }
-
-    /**
-     * Stores the details to edit the tag set.
-     */
-    public static class EditTagDescriptor {
-
-        private Set<Tag> tags = new HashSet<>();
-
-        public EditTagDescriptor() {}
-
-        /**
-         * Copy constructor.
-         */
-        public EditTagDescriptor(EditTagDescriptor toCopy) {
-            setTags(toCopy.tags);
-        }
-
-        /**
-         * Sets {@code tags}.
-         */
-        public void setTags(Set<Tag> tags) {
-            this.tags = new HashSet<>(tags);
-        }
-
-        /**
-         * Returns an unmodifiable tag set.
-         */
-        public Set<Tag> getTags() {
-            return Collections.unmodifiableSet(tags);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            if (other == this) {
-                return true;
-            }
-
-            if (!(other instanceof EditTagDescriptor)) {
-                return false;
-            }
-
-            EditTagDescriptor otherDescriptor = (EditTagDescriptor) other;
-            return Objects.equals(tags, otherDescriptor.tags);
-        }
-
-        @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .add("tags", tags)
-                    .toString();
-        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditParentCommand;
 import seedu.address.logic.commands.EditPersonCommand;
 import seedu.address.logic.commands.EditTagCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -27,6 +28,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         Map<String, Parser<? extends EditCommand>> parsers = new HashMap<>();
         parsers.put(EditPersonCommand.SUB_COMMAND_WORD, new EditPersonCommandParser());
         parsers.put(EditTagCommand.SUB_COMMAND_WORD, new EditTagCommandParser());
+        parsers.put(EditParentCommand.SUB_COMMAND_WORD, new EditParentCommandParser());
         parsers.put(EditApptCommand.SUB_COMMAND_WORD, new EditApptCommandParser());
         this.subCommandParsers = Collections.unmodifiableMap(parsers);
     }

--- a/src/main/java/seedu/address/logic/parser/EditTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditTagCommandParser.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditTagCommand;
-import seedu.address.logic.commands.EditTagCommand.EditTagDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
@@ -38,11 +37,8 @@ public class EditTagCommandParser implements Parser<EditTagCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTagCommand.MESSAGE_USAGE), pe);
         }
 
-        EditTagDescriptor editTagDescriptor = new EditTagDescriptor();
-
         Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        editTagDescriptor.setTags(tags);
 
-        return new EditTagCommand(index, editTagDescriptor);
+        return new EditTagCommand(index, tags);
     }
 }

--- a/src/main/java/seedu/address/model/person/PersonBuilder.java
+++ b/src/main/java/seedu/address/model/person/PersonBuilder.java
@@ -1,0 +1,128 @@
+package seedu.address.model.person;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.model.tag.Tag;
+
+/**
+ * Builder class for constructing {@code Person} objects safely.
+ */
+public class PersonBuilder {
+
+    private Name name;
+    private Phone phone;
+    private Email email;
+    private Address address;
+    private Set<Tag> tags;
+    private Optional<ParentName> parentName;
+    private Optional<LocalDateTime> appointmentStart;
+
+    /**
+     * Creates a builder initialized with the data of {@code personToCopy}.
+     */
+    public PersonBuilder(Person personToCopy) {
+        this.name = personToCopy.getName();
+        this.phone = personToCopy.getPhone();
+        this.email = personToCopy.getEmail();
+        this.address = personToCopy.getAddress();
+        this.tags = new HashSet<>(personToCopy.getTags());
+        this.parentName = personToCopy.getParentName();
+        this.appointmentStart = personToCopy.getAppointmentStart();
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code Person} being built.
+     *
+     * @param name the new name
+     * @return this {@code PersonBuilder} instance for method chaining
+     */
+    public PersonBuilder withName(Name name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Sets the {@code Phone} of the {@code Person} being built.
+     *
+     * @param phone the new phone number
+     * @return this {@code PersonBuilder} instance for method chaining
+     */
+    public PersonBuilder withPhone(Phone phone) {
+        this.phone = phone;
+        return this;
+    }
+
+    /**
+     * Sets the {@code Email} of the {@code Person} being built.
+     *
+     * @param email the new email address
+     * @return this {@code PersonBuilder} instance for method chaining
+     */
+    public PersonBuilder withEmail(Email email) {
+        this.email = email;
+        return this;
+    }
+
+    /**
+     * Sets the {@code Address} of the {@code Person} being built.
+     *
+     * @param address the new address
+     * @return this {@code PersonBuilder} instance for method chaining
+     */
+    public PersonBuilder withAddress(Address address) {
+        this.address = address;
+        return this;
+    }
+
+    /**
+     * Replaces the tag set of the {@code Person} being built.
+     * A defensive copy of the provided tag set is created.
+     *
+     * @param tags the new set of tags
+     * @return this {@code PersonBuilder} instance for method chaining
+     */
+    public PersonBuilder withTags(Set<Tag> tags) {
+        this.tags = new HashSet<>(tags);
+        return this;
+    }
+
+    /**
+     * Sets the {@code ParentName} of the {@code Person} being built.
+     *
+     * @param parentName the optional parent name
+     * @return this {@code PersonBuilder} instance for method chaining
+     */
+    public PersonBuilder withParentName(Optional<ParentName> parentName) {
+        this.parentName = parentName;
+        return this;
+    }
+
+    /**
+     * Sets the appointment start time of the {@code Person} being built.
+     *
+     * @param appointmentStart the optional appointment start time
+     * @return this {@code PersonBuilder} instance for method chaining
+     */
+    public PersonBuilder withAppointmentStart(Optional<LocalDateTime> appointmentStart) {
+        this.appointmentStart = appointmentStart;
+        return this;
+    }
+
+    /**
+     * Builds a {@code Person} with the current builder state.
+     */
+    public Person build() {
+        return new Person(
+                name,
+                phone,
+                email,
+                address,
+                tags,
+                parentName,
+                appointmentStart
+        );
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditTagCommandTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.EditTagCommand.EditTagDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -38,10 +37,9 @@ public class EditTagCommandTest {
     public void execute_replaceTagsUnfilteredList_success() {
         Person personInList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of(new Tag(VALID_TAG_JC), new Tag(VALID_TAG_GROUP1)));
+        Set<Tag> tags = Set.of(new Tag(VALID_TAG_JC), new Tag(VALID_TAG_GROUP1));
 
-        EditTagCommand editCommand = new EditTagCommand(INDEX_FIRST_PERSON, descriptor);
+        EditTagCommand editCommand = new EditTagCommand(INDEX_FIRST_PERSON, tags);
 
         Person editedPerson = new PersonBuilder(personInList)
                 .withTags(VALID_TAG_JC, VALID_TAG_GROUP1)
@@ -60,10 +58,9 @@ public class EditTagCommandTest {
     public void execute_clearTags_success() {
         Person personInList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of());
+        Set<Tag> tags = Set.of();
 
-        EditTagCommand editCommand = new EditTagCommand(INDEX_FIRST_PERSON, descriptor);
+        EditTagCommand editCommand = new EditTagCommand(INDEX_FIRST_PERSON, tags);
 
         Person editedPerson = new PersonBuilder(personInList)
                 .withTags()
@@ -84,10 +81,9 @@ public class EditTagCommandTest {
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of(new Tag(VALID_TAG_JC)));
+        Set<Tag> tags = Set.of(new Tag(VALID_TAG_JC));
 
-        EditTagCommand editCommand = new EditTagCommand(INDEX_FIRST_PERSON, descriptor);
+        EditTagCommand editCommand = new EditTagCommand(INDEX_FIRST_PERSON, tags);
 
         Person editedPerson = new PersonBuilder(personInFilteredList)
                 .withTags(VALID_TAG_JC)
@@ -106,24 +102,22 @@ public class EditTagCommandTest {
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
 
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of(new Tag(VALID_TAG_JC)));
+        Set<Tag> tags = Set.of(new Tag(VALID_TAG_JC));
 
-        EditTagCommand editCommand = new EditTagCommand(outOfBoundIndex, descriptor);
+        EditTagCommand editCommand = new EditTagCommand(outOfBoundIndex, tags);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of(new Tag(VALID_TAG_JC)));
+        Set<Tag> tags = Set.of(new Tag(VALID_TAG_JC));
 
-        final EditTagCommand standardCommand = new EditTagCommand(INDEX_FIRST_PERSON, descriptor);
+        final EditTagCommand standardCommand = new EditTagCommand(INDEX_FIRST_PERSON, tags);
 
         // same values -> returns true
-        EditTagDescriptor copyDescriptor = new EditTagDescriptor(descriptor);
-        EditTagCommand commandWithSameValues = new EditTagCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        Set<Tag> copyTags = Set.of(new Tag(VALID_TAG_JC));
+        EditTagCommand commandWithSameValues = new EditTagCommand(INDEX_FIRST_PERSON, copyTags);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -136,17 +130,22 @@ public class EditTagCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditTagCommand(INDEX_SECOND_PERSON, descriptor)));
+        assertFalse(standardCommand.equals(new EditTagCommand(INDEX_SECOND_PERSON, tags)));
+
+        // different tags -> returns false
+        Set<Tag> differentTags = Set.of(new Tag("DIFFERENT"));
+        assertFalse(standardCommand.equals(new EditTagCommand(INDEX_FIRST_PERSON, differentTags)));
     }
 
     @Test
     public void toStringMethod() {
         Index index = Index.fromOneBased(1);
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        EditTagCommand command = new EditTagCommand(index, descriptor);
+        Set<Tag> tags = Set.of(new Tag(VALID_TAG_JC));
+
+        EditTagCommand command = new EditTagCommand(index, tags);
 
         String expected = EditTagCommand.class.getCanonicalName()
-                + "{index=" + index + ", editTagDescriptor=" + descriptor + "}";
+                + "{index=" + index + ", tags=" + tags + "}";
 
         assertEquals(expected, command.toString());
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -75,10 +75,9 @@ public class AddressBookParserTest {
                         + EditTagCommand.SUB_COMMAND_WORD + " "
                         + INDEX_FIRST_PERSON.getOneBased() + " t/friend");
 
-        EditTagCommand.EditTagDescriptor descriptor = new EditTagCommand.EditTagDescriptor();
-        descriptor.setTags(Set.of(new Tag("friend")));
+        Set<Tag> tags = Set.of(new Tag("friend"));
 
-        assertEquals(new EditTagCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditTagCommand(INDEX_FIRST_PERSON, tags), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditTagCommandParserTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditTagCommand;
-import seedu.address.logic.commands.EditTagCommand.EditTagDescriptor;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -77,10 +76,9 @@ public class EditTagCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + TAG_DESC_JC;
 
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of(new Tag(VALID_TAG_JC)));
+        Set<Tag> tags = Set.of(new Tag(VALID_TAG_JC));
 
-        EditTagCommand expectedCommand = new EditTagCommand(targetIndex, descriptor);
+        EditTagCommand expectedCommand = new EditTagCommand(targetIndex, tags);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -90,10 +88,9 @@ public class EditTagCommandParserTest {
         Index targetIndex = INDEX_SECOND_PERSON;
         String userInput = targetIndex.getOneBased() + TAG_DESC_JC + TAG_DESC_GROUP1;
 
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of(new Tag(VALID_TAG_JC), new Tag(VALID_TAG_GROUP1)));
+        Set<Tag> tags = Set.of(new Tag(VALID_TAG_JC), new Tag(VALID_TAG_GROUP1));
 
-        EditTagCommand expectedCommand = new EditTagCommand(targetIndex, descriptor);
+        EditTagCommand expectedCommand = new EditTagCommand(targetIndex, tags);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -103,10 +100,9 @@ public class EditTagCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + "";
 
-        EditTagDescriptor descriptor = new EditTagDescriptor();
-        descriptor.setTags(Set.of());
+        Set<Tag> tags = Set.of();
 
-        EditTagCommand expectedCommand = new EditTagCommand(targetIndex, descriptor);
+        EditTagCommand expectedCommand = new EditTagCommand(targetIndex, tags);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }


### PR DESCRIPTION
Introduce a PersonBuilder to simplify Person reconstruction and improve extensibility when modifying Person fields.
* create new PersonBuilder class for safe and extensible Person updates
* fix issues in EditTagCommand caused by manual Person reconstruction
* update `edit appt` and `edit parent` commands to use PersonBuilder
* simplify tag editing by removing unnecessary descriptor wrapper
* update related test cases

Close #44 
Fix #45 