### PR TITLE
Fix bug to support prefix-style text in dsc

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -460,6 +460,8 @@ Details:
 * `r/RECURRENCE` is optional. Valid values are `NONE`, `WEEKLY`, `BIWEEKLY`, and `MONTHLY`.
 * If `r/` is omitted, TutorFlow uses `NONE`.
 * `dsc/` is required and should describe the session.
+* If the description contains text that looks like a prefix such as `d/` or `r/`, wrap the description in double
+  quotes.
 
 Examples:
 * `add appt 1 d/2026-01-29T08:00:00 dsc/Weekly algebra practice`
@@ -494,6 +496,8 @@ Details:
 * `d/DATETIME` must be in ISO 8601 local date-time format (`YYYY-MM-DDTHH:MM:SS`).
 * `r/RECURRENCE` supports `NONE`, `WEEKLY`, `BIWEEKLY`, and `MONTHLY`.
 * `dsc/DESCRIPTION` updates the session description.
+* If the description contains text that looks like a prefix such as `d/` or `r/`, wrap the description in double
+  quotes.
 * Any field you omit remains unchanged.
 
 Examples:

--- a/src/main/java/seedu/address/logic/parser/AddApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddApptCommandParser.java
@@ -21,13 +21,15 @@ public class AddApptCommandParser implements Parser<AddApptCommand> {
     @Override
     public AddApptCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-                PREFIX_DATE, PREFIX_RECURRENCE, PREFIX_DESCRIPTION);
+        AppointmentDescriptionParser.ExtractionResult descriptionResult =
+                AppointmentDescriptionParser.extract(args, PREFIX_DATE, PREFIX_RECURRENCE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(descriptionResult.getRemainingArgs(),
+                PREFIX_DATE, PREFIX_RECURRENCE);
 
         Index index = ParserUtil.parseIndex(argMultimap.getPreamble(), AddApptCommand.MESSAGE_USAGE);
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE, PREFIX_RECURRENCE, PREFIX_DESCRIPTION);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE, PREFIX_RECURRENCE);
 
-        if (argMultimap.getValue(PREFIX_DATE).isEmpty() || argMultimap.getValue(PREFIX_DESCRIPTION).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_DATE).isEmpty() || descriptionResult.getDescription().isEmpty()) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                     AddApptCommand.MESSAGE_USAGE));
         }
@@ -39,7 +41,7 @@ public class AddApptCommandParser implements Parser<AddApptCommand> {
             recurrence = ParserUtil.parseRecurrence(argMultimap.getValue(PREFIX_RECURRENCE).get());
         }
 
-        String description = argMultimap.getValue(PREFIX_DESCRIPTION).get().trim();
+        String description = descriptionResult.getDescription().orElseThrow();
         if (description.isEmpty()) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                     AddApptCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/AddApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddApptCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RECURRENCE;
 
 import java.time.LocalDateTime;

--- a/src/main/java/seedu/address/logic/parser/AppointmentDescriptionParser.java
+++ b/src/main/java/seedu/address/logic/parser/AppointmentDescriptionParser.java
@@ -28,7 +28,8 @@ final class AppointmentDescriptionParser {
         int valueStart = descriptionStart + CliSyntax.PREFIX_DESCRIPTION.getPrefix().length();
         ParseBounds bounds = parseDescriptionBounds(args, valueStart, otherPrefixes);
 
-        int duplicateDescriptionStart = findValidPrefixPosition(args, CliSyntax.PREFIX_DESCRIPTION, bounds.endExclusive);
+        int duplicateDescriptionStart =
+                findValidPrefixPosition(args, CliSyntax.PREFIX_DESCRIPTION, bounds.endExclusive);
         if (duplicateDescriptionStart != -1) {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(CliSyntax.PREFIX_DESCRIPTION));
         }
@@ -36,7 +37,10 @@ final class AppointmentDescriptionParser {
         String description = bounds.quoted
                 ? args.substring(valueStart + 1, bounds.endExclusive - 1)
                 : args.substring(valueStart, bounds.endExclusive);
-        String remainingArgs = (args.substring(0, descriptionStart) + " " + args.substring(bounds.endExclusive)).trim();
+        String remainingArgs = args.substring(0, descriptionStart)
+                + " "
+                + args.substring(bounds.endExclusive);
+        remainingArgs = remainingArgs.trim();
 
         return new ExtractionResult(remainingArgs, Optional.of(description.trim()));
     }

--- a/src/main/java/seedu/address/logic/parser/AppointmentDescriptionParser.java
+++ b/src/main/java/seedu/address/logic/parser/AppointmentDescriptionParser.java
@@ -1,0 +1,114 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Extracts the {@code dsc/} field for appointment commands.
+ * Supports quoted descriptions so prefix-like text such as {@code d/} inside the description
+ * is not misinterpreted as a new field.
+ */
+final class AppointmentDescriptionParser {
+
+    private AppointmentDescriptionParser() {}
+
+    static ExtractionResult extract(String args, Prefix... otherPrefixes) throws ParseException {
+        requireNonNull(args);
+
+        int descriptionStart = findValidPrefixPosition(args, CliSyntax.PREFIX_DESCRIPTION, 0);
+        if (descriptionStart == -1) {
+            return new ExtractionResult(args, Optional.empty());
+        }
+
+        int valueStart = descriptionStart + CliSyntax.PREFIX_DESCRIPTION.getPrefix().length();
+        ParseBounds bounds = parseDescriptionBounds(args, valueStart, otherPrefixes);
+
+        int duplicateDescriptionStart = findValidPrefixPosition(args, CliSyntax.PREFIX_DESCRIPTION, bounds.endExclusive);
+        if (duplicateDescriptionStart != -1) {
+            throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(CliSyntax.PREFIX_DESCRIPTION));
+        }
+
+        String description = bounds.quoted
+                ? args.substring(valueStart + 1, bounds.endExclusive - 1)
+                : args.substring(valueStart, bounds.endExclusive);
+        String remainingArgs = (args.substring(0, descriptionStart) + " " + args.substring(bounds.endExclusive)).trim();
+
+        return new ExtractionResult(remainingArgs, Optional.of(description.trim()));
+    }
+
+    private static ParseBounds parseDescriptionBounds(String args, int valueStart, Prefix... otherPrefixes)
+            throws ParseException {
+        if (valueStart < args.length() && args.charAt(valueStart) == '"') {
+            int closingQuote = args.indexOf('"', valueStart + 1);
+            if (closingQuote == -1) {
+                throw new ParseException("Appointment description is missing a closing quote.");
+            }
+            return new ParseBounds(closingQuote + 1, true);
+        }
+
+        int endExclusive = args.length();
+        for (Prefix prefix : Arrays.asList(otherPrefixes)) {
+            int prefixPosition = findValidPrefixPosition(args, prefix, valueStart);
+            if (prefixPosition != -1 && prefixPosition < endExclusive) {
+                endExclusive = prefixPosition;
+            }
+        }
+
+        return new ParseBounds(endExclusive, false);
+    }
+
+    private static int findValidPrefixPosition(String argsString, Prefix prefix, int fromIndex) {
+        int searchIndex = Math.max(fromIndex, 0);
+        String prefixValue = prefix.getPrefix();
+
+        while (searchIndex <= argsString.length() - prefixValue.length()) {
+            int prefixIndex = argsString.indexOf(prefixValue, searchIndex);
+            if (prefixIndex == -1) {
+                return -1;
+            }
+
+            boolean isAtStart = prefixIndex == 0;
+            boolean hasLeadingWhitespace = !isAtStart && Character.isWhitespace(argsString.charAt(prefixIndex - 1));
+            if (isAtStart || hasLeadingWhitespace) {
+                return prefixIndex;
+            }
+
+            searchIndex = prefixIndex + 1;
+        }
+
+        return -1;
+    }
+
+    static final class ExtractionResult {
+        private final String remainingArgs;
+        private final Optional<String> description;
+
+        private ExtractionResult(String remainingArgs, Optional<String> description) {
+            this.remainingArgs = remainingArgs;
+            this.description = description;
+        }
+
+        String getRemainingArgs() {
+            return remainingArgs;
+        }
+
+        Optional<String> getDescription() {
+            return description;
+        }
+    }
+
+    private static final class ParseBounds {
+        private final int endExclusive;
+        private final boolean quoted;
+
+        private ParseBounds(int endExclusive, boolean quoted) {
+            this.endExclusive = endExclusive;
+            this.quoted = quoted;
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -24,11 +24,13 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
     @Override
     public EditApptCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-                PREFIX_SESSION, PREFIX_DATE, PREFIX_RECURRENCE, PREFIX_DESCRIPTION);
+        AppointmentDescriptionParser.ExtractionResult descriptionResult =
+                AppointmentDescriptionParser.extract(args, PREFIX_SESSION, PREFIX_DATE, PREFIX_RECURRENCE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(descriptionResult.getRemainingArgs(),
+                PREFIX_SESSION, PREFIX_DATE, PREFIX_RECURRENCE);
 
         Index personIndex = ParserUtil.parseIndex(argMultimap.getPreamble(), EditApptCommand.MESSAGE_USAGE);
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SESSION, PREFIX_DATE, PREFIX_RECURRENCE, PREFIX_DESCRIPTION);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SESSION, PREFIX_DATE, PREFIX_RECURRENCE);
 
         if (argMultimap.getValue(PREFIX_SESSION).isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditApptCommand.MESSAGE_USAGE));
@@ -48,8 +50,8 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
         }
 
         Optional<String> description = Optional.empty();
-        if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
-            String parsedDescription = argMultimap.getValue(PREFIX_DESCRIPTION).get().trim();
+        if (descriptionResult.getDescription().isPresent()) {
+            String parsedDescription = descriptionResult.getDescription().get().trim();
             if (parsedDescription.isEmpty()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditApptCommand.MESSAGE_USAGE));
             }

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RECURRENCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SESSION;
 

--- a/src/test/java/seedu/address/logic/parser/AddApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddApptCommandParserTest.java
@@ -79,4 +79,16 @@ public class AddApptCommandParserTest {
                 VALID_APPOINTMENT_DESCRIPTION);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
+
+    @Test
+    public void parse_quotedDescriptionContainingPrefixLikeText_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased()
+                + " d/2000-01-01T00:00:00 dsc/\" d d/lol \"";
+        AddApptCommand expectedCommand = new AddApptCommand(targetIndex,
+                LocalDateTime.parse("2000-01-01T00:00:00"),
+                Recurrence.NONE,
+                "d d/lol");
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -66,4 +66,13 @@ public class EditApptCommandParserTest {
                         Optional.of(Recurrence.WEEKLY),
                         Optional.of("Weekly algebra practice")));
     }
+
+    @Test
+    public void parse_quotedDescriptionContainingPrefixLikeText_success() {
+        assertParseSuccess(parser, "1 " + PREFIX_SESSION + "1 dsc/\" d d/lol \"",
+                new EditApptCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of("d d/lol")));
+    }
 }


### PR DESCRIPTION
## Summary
Fix appointment description parsing so quoted `dsc/` values can contain prefix-like text such as `d/` or `r/` without being misparsed as new fields.

Previously, a command like:

`add appt 7 d/2000-01-01T00:00:00 dsc/" d d/lol "`

could fail because the generic argument tokenizer treated ` d/` inside the description as a new date prefix. This made some descriptions depend on their exact spacing/content in unintuitive ways.

## Changes
- Added a small parser helper to extract appointment `dsc/` values before normal prefix tokenization
- Supported quoted appointment descriptions so prefix-like text inside quotes is treated as plain description text
- Applied the fix to both:
  - `add appt`
  - `edit appt`
- Updated the User Guide to document that descriptions containing prefix-like text should be wrapped in double quotes
- Added parser tests covering quoted descriptions with embedded prefix-like text

## Before
- `add appt 7 d/2000-01-01T00:00:00 dsc/" dd/lol "` could be accepted
- `add appt 7 d/2000-01-01T00:00:00 dsc/" d d/lol "` could fail because ` d/` was interpreted as a new prefix
- The behavior was inconsistent and depended on the exact description text

## After
- Quoted appointment descriptions are parsed as a single description value
- Prefix-like text such as `d/` or `r/` inside quoted descriptions no longer breaks parsing
- Example:
  - `add appt 7 d/2000-01-01T00:00:00 dsc/" d d/lol "` now parses successfully
  - `edit appt 7 s/1 dsc/" d d/lol "` also works

## Why
This keeps appointment parsing predictable and prevents user content from being accidentally treated as command structure.

Without this fix, descriptions that merely resemble prefixes can cause valid user input to fail.

## Testing
Ran:
- `./gradlew test --tests seedu.address.logic.parser.AddApptCommandParserTest --tests seedu.address.logic.parser.EditApptCommandParserTest`