### PR TITLE
Fix acad prefix handling and align tag/subject casing semantics with docs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -214,8 +214,8 @@ Format: `add tag INDEX t/TAG [t/TAG]...`
 Details:
 * Adds the given tag or tags to the student at `INDEX`.
 * At least one `t/` prefix is required.
-* Existing tags are kept; tags already present are ignored.
-* Duplicate tag names within the same command are also ignored.
+* Existing tags are kept; tags already present are ignored (case-insensitive).
+* Duplicate tag names within the same command are also ignored (case-insensitive).
 
 Examples:
 * `add tag 1 t/JC`
@@ -245,7 +245,7 @@ Format: `delete tag INDEX t/TAG_INDEX [t/TAG_INDEX]...`
 Details:
 * `INDEX` is the student index in the current displayed list.
 * Each `TAG_INDEX` is taken from the numbered tag list in that student's detail panel.
-* Tag names are stored and displayed in **title case** (e.g. `jc` -> `Jc`) and listed in **case-insensitive alphabetical order**.
+* Tag names keep the user's input casing and are listed in **case-insensitive alphabetical order**.
 * At least one `t/` prefix is required.
 
 Examples:
@@ -288,8 +288,9 @@ Details:
 * `l/LEVEL` is optional and applies to the subject immediately before it.
 * Accepted levels are `basic` and `strong` (case-insensitive).
 * Existing subjects not named in the command are kept unchanged.
-* If the student already has a subject with the same name, that subject is replaced by the new entry.
-* Duplicate subject names within the same command are invalid.
+* If the student already has a subject with the same name (case-insensitive), that subject is replaced by the new entry.
+* If the replacement is identical to the existing entry, there is no visible change.
+* Duplicate subject names within the same command are invalid (case-insensitive).
 
 Examples:
 * `add acad 1 s/Math l/Strong`
@@ -307,7 +308,7 @@ Details:
 * Use `s/` with no value to clear all subjects.
 * Use `dsc/` with no value to clear the academic description.
 * Only one `dsc/` field is allowed per command.
-* Duplicate subject names within the same command are invalid.
+* Duplicate subject names within the same command are invalid (case-insensitive).
 
 Examples:
 * `edit acad 1 s/Math l/Strong s/Science`
@@ -324,7 +325,7 @@ Format: `delete acad INDEX s/SUBJECT_INDEX [s/SUBJECT_INDEX]...`
 Details:
 * `INDEX` is the student index in the current displayed list.
 * Each `SUBJECT_INDEX` is taken from the numbered subject list in that student's detail panel.
-* Subject names are stored and displayed in **title case** (e.g. `math` -> `Math`) and listed in **case-insensitive alphabetical order**.
+* Subject names keep the user's input casing and are listed in **case-insensitive alphabetical order**.
 * At least one `s/` prefix is required.
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/AddAcademicsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAcademicsCommand.java
@@ -63,7 +63,7 @@ public class AddAcademicsCommand extends AddCommand {
 
         // Upsert: for each new subject, remove existing with same name, then add
         for (Subject newSub : subjectsToAdd) {
-            updatedSubjects.removeIf(s -> s.getName().equals(newSub.getName()));
+            updatedSubjects.removeIf(s -> s.getName().equalsIgnoreCase(newSub.getName()));
             updatedSubjects.add(newSub);
         }
 

--- a/src/main/java/seedu/address/logic/parser/AcademicsParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/AcademicsParserUtil.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.academic.Level;
@@ -17,6 +18,8 @@ import seedu.address.model.academic.Subject;
  * Utility class for parsing subject and level sequences in academics commands.
  */
 public class AcademicsParserUtil {
+
+    private static final Pattern UNKNOWN_PREFIX_TOKEN = Pattern.compile("\\b[\\p{Alnum}]+/");
 
     /**
      * Parses a string containing subject and level prefixes into a list of subjects.
@@ -57,6 +60,11 @@ public class AcademicsParserUtil {
                 int next = findNextPrefix(input, start);
 
                 String name = input.substring(start, next).trim();
+
+                if (containsUnknownPrefixToken(name)) {
+                    throw new ParseException(
+                            String.format(MESSAGE_INVALID_COMMAND_FORMAT, commandUsage));
+                }
 
                 if (name.isEmpty()) {
                     if (allowClear) {
@@ -123,5 +131,19 @@ public class AcademicsParserUtil {
         }
 
         return Math.min(nextSubject, nextLevel);
+    }
+
+    private static boolean containsUnknownPrefixToken(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+
+        String normalized = value.trim().toLowerCase();
+        if (normalized.startsWith(PREFIX_SUBJECT.getPrefix())
+                || normalized.startsWith(PREFIX_LEVEL.getPrefix())) {
+            return false;
+        }
+
+        return UNKNOWN_PREFIX_TOKEN.matcher(normalized).find();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddAcademicsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAcademicsCommandParser.java
@@ -63,7 +63,7 @@ public class AddAcademicsCommandParser implements Parser<AddAcademicsCommand> {
         // Check for duplicate subject names
         Set<String> seen = new HashSet<>();
         for (Subject s : subjects) {
-            if (!seen.add(s.getName())) {
+            if (!seen.add(s.getName().toLowerCase())) {
                 throw new ParseException("Duplicate subjects are not allowed.");
             }
         }

--- a/src/main/java/seedu/address/logic/parser/EditAcademicsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAcademicsCommandParser.java
@@ -103,7 +103,7 @@ public class EditAcademicsCommandParser implements Parser<EditAcademicsCommand> 
                 List<Subject> subjects = parseResult.get();
                 Set<String> seen = new HashSet<>();
                 for (Subject s : subjects) {
-                    if (!seen.add(s.getName())) {
+                    if (!seen.add(s.getName().toLowerCase())) {
                         throw new ParseException("Duplicate subjects are not allowed.");
                     }
                 }

--- a/src/main/java/seedu/address/model/academic/Subject.java
+++ b/src/main/java/seedu/address/model/academic/Subject.java
@@ -6,8 +6,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.util.Objects;
 import java.util.Optional;
 
-import seedu.address.model.util.StringUtil;
-
 /**
  * Represents a Subject with an optional level.
  * Guarantees: immutable; name is valid; level is optional.
@@ -34,10 +32,9 @@ public class Subject {
         String trimmed = name.trim();
         checkArgument(!trimmed.isEmpty(), MESSAGE_CONSTRAINTS);
 
-        String normalized = StringUtil.toTitleCase(trimmed);
-        checkArgument(isValidSubjectName(normalized), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidSubjectName(trimmed), MESSAGE_CONSTRAINTS);
 
-        this.name = normalized;
+        this.name = trimmed;
         this.level = level;
     }
 
@@ -81,12 +78,12 @@ public class Subject {
         }
 
         Subject otherSubject = (Subject) other;
-        return name.equals(otherSubject.name)
+        return name.equalsIgnoreCase(otherSubject.name)
                 && Objects.equals(level, otherSubject.level);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, level);
+        return Objects.hash(name.toLowerCase(), level);
     }
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -3,8 +3,6 @@ package seedu.address.model.tag;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import seedu.address.model.util.StringUtil;
-
 /**
  * Represents a Tag in the address book.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
@@ -28,10 +26,9 @@ public class Tag {
         String trimmed = tagName.trim();
         checkArgument(!trimmed.isEmpty(), MESSAGE_CONSTRAINTS);
 
-        String normalized = StringUtil.toTitleCase(trimmed);
-        checkArgument(isValidTagName(normalized), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidTagName(trimmed), MESSAGE_CONSTRAINTS);
 
-        this.tagName = normalized;
+        this.tagName = trimmed;
     }
 
     /**
@@ -53,12 +50,12 @@ public class Tag {
         }
 
         Tag otherTag = (Tag) other;
-        return tagName.equals(otherTag.tagName);
+        return tagName.equalsIgnoreCase(otherTag.tagName);
     }
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return tagName.toLowerCase().hashCode();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddAcademicsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAcademicsCommandParserTest.java
@@ -118,4 +118,17 @@ public class AddAcademicsCommandParserTest {
         assertParseFailure(parser, "1 s/Math s/Math",
                 "Duplicate subjects are not allowed.");
     }
+
+    @Test
+    public void parse_duplicateSubjectsDifferentCase_failure() {
+        assertParseFailure(parser, "1 s/Math s/mAtH",
+                "Duplicate subjects are not allowed.");
+    }
+
+    @Test
+    public void parse_unknownPrefixLikeToken_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddAcademicsCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1 s/Math desc/progress", expectedMessage);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/EditAcademicsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditAcademicsCommandParserTest.java
@@ -188,6 +188,14 @@ public class EditAcademicsCommandParserTest {
     }
 
     @Test
+    public void parse_duplicateSubjectsDifferentCase_failure() {
+        Index index = INDEX_FIRST_PERSON;
+        String input = index.getOneBased() + " s/Math s/mAtH";
+
+        assertParseFailure(parser, input, "Duplicate subjects are not allowed.");
+    }
+
+    @Test
     public void parse_levelWithoutSubject_failure() {
         Index index = INDEX_FIRST_PERSON;
         String input = index.getOneBased() + " l/Strong";
@@ -281,5 +289,13 @@ public class EditAcademicsCommandParserTest {
 
         assertParseSuccess(parser, input,
                 new EditAcademicsCommand(index, descriptor));
+    }
+
+    @Test
+    public void parse_unknownPrefixLikeToken_failure() {
+        Index index = INDEX_FIRST_PERSON;
+        String input = index.getOneBased() + " s/Math desc/progress";
+
+        assertParseFailure(parser, input, MESSAGE_INVALID_SUBJECT_FORMAT);
     }
 }

--- a/src/test/java/seedu/address/model/academic/SubjectTest.java
+++ b/src/test/java/seedu/address/model/academic/SubjectTest.java
@@ -23,19 +23,19 @@ public class SubjectTest {
     @Test
     public void constructor_validNameWithSpaces_success() {
         Subject subject = new Subject("data structures", null);
-        assertEquals("Data Structures", subject.getName());
+        assertEquals("data structures", subject.getName());
     }
 
     @Test
     public void constructor_trimsWhitespace_success() {
         Subject subject = new Subject("   discrete math   ", null);
-        assertEquals("Discrete Math", subject.getName());
+        assertEquals("discrete math", subject.getName());
     }
 
     @Test
-    public void constructor_normalizesCase_success() {
+    public void constructor_preservesCase_success() {
         Subject subject = new Subject("mIxEd CaSe", null);
-        assertEquals("Mixed Case", subject.getName());
+        assertEquals("mIxEd CaSe", subject.getName());
     }
 
     @Test
@@ -51,13 +51,13 @@ public class SubjectTest {
     @Test
     public void toString_noLevel_returnsNameOnly() {
         Subject subject = new Subject("math", null);
-        assertEquals("Math", subject.toString());
+        assertEquals("math", subject.toString());
     }
 
     @Test
     public void toString_withLevel_returnsFormatted() {
         Subject subject = new Subject("math", Level.STRONG);
-        assertEquals("Math-Strong", subject.toString());
+        assertEquals("math-Strong", subject.toString());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class SubjectTest {
         Subject s1 = new Subject("math", Level.STRONG);
         Subject s2 = new Subject("Math", Level.STRONG);
 
-        // after normalization → equal
+        // equality ignores case
         assert(s1.equals(s2));
     }
 

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -22,19 +22,19 @@ public class TagTest {
     @Test
     public void constructor_validTagNameWithSpaces_success() {
         Tag tag = new Tag("close friend");
-        assertEquals("Close Friend", tag.tagName);
+        assertEquals("close friend", tag.tagName);
     }
 
     @Test
     public void constructor_trimsWhitespace_success() {
         Tag tag = new Tag("   best buddy   ");
-        assertEquals("Best Buddy", tag.tagName);
+        assertEquals("best buddy", tag.tagName);
     }
 
     @Test
-    public void constructor_normalizesCase_success() {
+    public void constructor_preservesCase_success() {
         Tag tag = new Tag("mIxEd CaSe");
-        assertEquals("Mixed Case", tag.tagName);
+        assertEquals("mIxEd CaSe", tag.tagName);
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR fixes the acad parsing bug around wrong prefix-like input and aligns tag/subject casing behavior with expected semantics and documentation.

## Problem
* edit acad ... s/Math desc/progress could surface a subject constraint error instead of a command format/prefix error.
* Tag/Subject values were being forced to title case, which reduced expressiveness for casing-sensitive names.
* Duplicate checks and upsert matching needed consistent case-insensitive behavior.

## What changed
* Acad parser utility now detects unknown prefix-like tokens in subject payload and throws invalid command format.
* Duplicate subject detection in add/edit acad parser is now case-insensitive.
* Add acad upsert matching now compares subject names case-insensitively.
* Tag and Subject now preserve user-entered casing.
* Tag and Subject equality/hash semantics are case-insensitive.
* User Guide updated to reflect:
* case-insensitive dedup behavior
* preserved casing for tags/subjects
* add acad may result in no visible change if replacement is identical


## Testing
* Updated and added unit tests for:
* acad wrong-prefix regression
* case-insensitive duplicate-subject rejection
* Tag/Subject preserve-casing expectations
* Full test/check run completed locally.

## Fix
* Close #247
* Close #283 