### PR TITLE
Update ParserUtil to reject large amount values

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -492,7 +492,9 @@ Format: `edit billing INDEX [a/AMOUNT] [d/DATE]`
 Details:
 * At least one of `a/` or `d/` must be provided.
 * `a/AMOUNT` must be a non-negative number.
-* `d/DATE` must be in ISO 8601 date format: `YYYY-MM-DD`.
+* Amounts are displayed to 2 decimal places in the UI. If you enter more decimal places,
+  the displayed value is rounded to 2 decimal places.
+* `d/DATE` must be in ISO 8601 local date format: `YYYY-MM-DD`.
 * This command changes billing settings only. It does not add a payment record.
 
 Examples:

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,7 +37,7 @@ public class ParserUtil {
             "Date-time must be in ISO 8601 local format, e.g. 2026-01-13T08:00:00";
     public static final String MESSAGE_INVALID_AMOUNT = "Amount must be a non-negative number.";
     public static final String MESSAGE_INVALID_AMOUNT_PRECISION =
-            "Amount is too large to be represented exactly. Please enter a smaller amount.";
+            "Amount is too large to be saved accurately. Please enter a smaller amount.";
     public static final String MESSAGE_INVALID_RECURRENCE =
             "Recurrence must be one of: WEEKLY, BIWEEKLY, MONTHLY, NONE";
     /**
@@ -160,11 +160,13 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String amount} into a non-negative {@code double} that is
-     * exactly representable as a {@code double}.
+     * Parses a {@code String amount} into a non-negative {@code double}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code amount} is invalid.
+     * Rejects values that would change when converted to {@code double} for storage.
+     *
+     * @throws ParseException if the given {@code amount} is invalid, negative, or would
+     *         change value when stored.
      */
     public static double parseAmount(String amount) throws ParseException {
         requireNonNull(amount);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -35,6 +36,8 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_DATE_TIME =
             "Date-time must be in ISO 8601 local format, e.g. 2026-01-13T08:00:00";
     public static final String MESSAGE_INVALID_AMOUNT = "Amount must be a non-negative number.";
+    public static final String MESSAGE_INVALID_AMOUNT_PRECISION =
+            "Amount is too large to be represented exactly. Please enter a smaller amount.";
     public static final String MESSAGE_INVALID_RECURRENCE =
             "Recurrence must be one of: WEEKLY, BIWEEKLY, MONTHLY, NONE";
     /**
@@ -157,7 +160,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String amount} into a positive {@code double} that is greater than or equals to 0.
+     * Parses a {@code String amount} into a non-negative {@code double} that is
+     * exactly representable as a {@code double}.
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code amount} is invalid.
@@ -166,9 +170,14 @@ public class ParserUtil {
         requireNonNull(amount);
         String trimmedAmount = amount.trim();
         try {
-            double parsedAmount = Double.parseDouble(trimmedAmount);
+            BigDecimal parsedAmountDecimal = new BigDecimal(trimmedAmount);
+            double parsedAmount = parsedAmountDecimal.doubleValue();
             if (!Double.isFinite(parsedAmount) || parsedAmount < 0) {
                 throw new ParseException(MESSAGE_INVALID_AMOUNT);
+            }
+
+            if (parsedAmountDecimal.compareTo(BigDecimal.valueOf(parsedAmount)) != 0) {
+                throw new ParseException(MESSAGE_INVALID_AMOUNT_PRECISION);
             }
             return parsedAmount;
         } catch (NumberFormatException e) {

--- a/src/test/java/seedu/address/logic/parser/EditBillingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditBillingCommandParserTest.java
@@ -45,6 +45,7 @@ public class EditBillingCommandParserTest {
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_AMOUNT_DESC, ParserUtil.MESSAGE_INVALID_AMOUNT);
         assertParseFailure(parser, "1 a/notANumber", ParserUtil.MESSAGE_INVALID_AMOUNT);
+        assertParseFailure(parser, "1 a/9999999999999999", ParserUtil.MESSAGE_INVALID_AMOUNT_PRECISION);
         assertParseFailure(parser, "1 d/invalidDate", ParserUtil.MESSAGE_INVALID_DATE);
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditBillingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditBillingCommandParserTest.java
@@ -50,6 +50,14 @@ public class EditBillingCommandParserTest {
     }
 
     @Test
+    public void parse_amountMoreThanTwoDecimalPlaces_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + " a/0.19999999";
+        EditBillingCommand expectedCommand = new EditBillingCommand(targetIndex, 0.19999999);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
     public void parse_amountSpecified_success() {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + VALID_AMOUNT_DESC;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -233,8 +233,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseAmount_precisionLossValue_throwsParseException() {
-        assertThrows(ParseException.class, ParserUtil.MESSAGE_INVALID_AMOUNT_PRECISION,
-                () -> ParserUtil.parseAmount("9999999999999999"));
+        assertThrows(ParseException.class, ParserUtil.MESSAGE_INVALID_AMOUNT_PRECISION, () ->
+            ParserUtil.parseAmount("9999999999999999"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -232,6 +232,12 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseAmount_precisionLossValue_throwsParseException() {
+        assertThrows(ParseException.class, ParserUtil.MESSAGE_INVALID_AMOUNT_PRECISION,
+                () -> ParserUtil.parseAmount("9999999999999999"));
+    }
+
+    @Test
     public void parseAmount_infiniteValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount("-Infinity"));
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount("Infinity"));
@@ -246,6 +252,11 @@ public class ParserUtilTest {
     public void parseAmount_validValueWithWhitespace_returnsAmount() throws Exception {
         String valueWithWhitespace = WHITESPACE + VALID_AMOUNT + WHITESPACE;
         assertEquals(Double.parseDouble(VALID_AMOUNT), ParserUtil.parseAmount(valueWithWhitespace));
+    }
+
+    @Test
+    public void parseAmount_zeroValue_returnsAmount() throws Exception {
+        assertEquals(0.0, ParserUtil.parseAmount("0"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -238,6 +238,16 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseAmount_moreThanTwoDecimalPlaces_returnsAmount() throws Exception {
+        assertEquals(Double.parseDouble("0.19999999"), ParserUtil.parseAmount("0.19999999"));
+    }
+
+    @Test
+    public void parseAmount_trailingZeroDecimals_returnsAmount() throws Exception {
+        assertEquals(0.2, ParserUtil.parseAmount("0.2000"));
+    }
+
+    @Test
     public void parseAmount_infiniteValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount("-Infinity"));
         assertThrows(ParseException.class, () -> ParserUtil.parseAmount("Infinity"));


### PR DESCRIPTION
Proper way is to change the model to use BigDecimal to store the amount, but to limit the LoC change it was implemented this way instead. Maybe we can add in DG under "Planned Enhancements" to use `BigDecimal` instead for the amount.

Close #280 