### PR TITLE
Fix next-session display for completed one-time appts

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -14,6 +14,7 @@ import seedu.address.commons.util.AppClock;
 import seedu.address.model.academic.Subject;
 import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Person;
+import seedu.address.model.recurrence.Recurrence;
 import seedu.address.model.session.ScheduledSession;
 import seedu.address.model.tag.Tag;
 
@@ -157,7 +158,11 @@ public class PersonCard extends UiPart<Region> {
     }
 
     private String formatNextSessionSummary(Person person) {
-        return person.getNextAppointment()
+        return person.getAppointment().getSessions().stream()
+            .filter(session -> session.getRecurrence() != Recurrence.NONE
+                || session.getAttendanceHistory().isEmpty())
+            .filter(session -> !session.getNext().isBefore(AppClock.now()))
+            .min((first, second) -> first.getNext().compareTo(second.getNext()))
                 .map(this::formatNextSessionSummary)
                 .orElse("Next: No upcoming sessions");
     }

--- a/src/main/java/seedu/address/ui/PersonDetailPanel.java
+++ b/src/main/java/seedu/address/ui/PersonDetailPanel.java
@@ -23,6 +23,7 @@ import seedu.address.commons.util.AppClock;
 import seedu.address.model.academic.Subject;
 import seedu.address.model.attendance.Attendance;
 import seedu.address.model.person.Person;
+import seedu.address.model.recurrence.Recurrence;
 import seedu.address.model.session.ScheduledSession;
 import seedu.address.model.tag.Tag;
 
@@ -295,6 +296,12 @@ public class PersonDetailPanel extends UiPart<Region> {
     }
 
     private String formatAppointmentMeta(ScheduledSession session) {
+        if (session.getRecurrence() == Recurrence.NONE && !session.getAttendanceHistory().isEmpty()) {
+            LocalDateTime completedAt = session.getAttendanceHistory().getLastRecord()
+                    .map(Attendance::getRecordedAt)
+                    .orElse(session.getNext());
+            return "Completed: " + formatAttendanceDate(completedAt);
+        }
         return "Next: " + formatDateTime(session.getNext());
     }
 
@@ -324,10 +331,12 @@ public class PersonDetailPanel extends UiPart<Region> {
 
     private String formatNextSessionSummary(Person person) {
         return person.getAppointment().getSessions().stream()
-                .map(ScheduledSession::getNext)
-                .filter(next -> next != null)
-                .min(Comparator.naturalOrder())
-                .map(this::formatDateTime)
+            .filter(session -> session.getRecurrence() != Recurrence.NONE
+                || session.getAttendanceHistory().isEmpty())
+            .filter(session -> !session.getNext().isBefore(AppClock.now()))
+            .map(ScheduledSession::getNext)
+            .min(Comparator.naturalOrder())
+            .map(this::formatDateTime)
                 .orElse("No upcoming sessions");
     }
 


### PR DESCRIPTION
This patch fixes misleading Next-session UI behaviour where one-time sessions could still appear as upcoming after attendance had already been recorded.

this approach was chosen to keep the change localized to UI formatting, preserve existing model semantics and call sites, reduce regression risk, and stay within the LoC-change limit.