### PR TITLE
Find substring behaviour for student and parent fields

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -92,10 +92,6 @@ For commands such as `delete tag`, `delete acad`, `delete appt`, and `add attd`,
 * For commands that use prefixes, the order of prefixed fields usually does not matter.
   Example: `p/91234567 n/John Doe` is accepted for commands that expect both fields.
 
-* `find` commands narrow the **currently displayed list** instead of always searching all students.
-  This means you can combine multiple `find` commands to refine results step by step.
-  Use `list` if you want to reset the view and search from the full student list again.
-
 * Whenever a command uses `INDEX`, it must be a positive integer such as `1`, `2`, or `3`.
 
 * Unless stated otherwise, `INDEX` refers to the **currently displayed student list**, not to a permanent student ID.
@@ -104,6 +100,19 @@ For commands such as `delete tag`, `delete acad`, `delete appt`, and `add attd`,
 * Commands without parameters, such as `help`, `list`, `clear`, and `exit`, ignore extra text after the command word.
 
 * If you are using a PDF version of this guide, be careful when copying multi-line commands. Some PDF viewers may remove spaces around line breaks.
+
+</div>
+
+<div markdown="block" class="alert alert-info">
+
+**How finding works**
+
+* `find` commands search within the **currently displayed list**, not always the full student list.
+* You can run multiple `find` commands one after another to narrow results step by step.
+* Use `list` to reset back to the full student list before searching again.
+* For most `find` commands, TutorFlow looks for your search word anywhere in the text and ignores upper/lower case.
+  Example: `al` can match `Alex`.
+* Date-based `find` commands (`find appt`, `find billing`) search by date or month instead of text.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -189,8 +189,8 @@ Details:
   Example: `alex` matches `Alex`
 * The order of keywords does not matter.
 * Only student names are searched.
-* Matching is by full word, not substring.
-  Example: `Al` does not match `Alex`
+* Matching is by substring.
+* Example: `Al` matches `Alex`
 * A student is returned if the name matches **at least one** keyword.
 
 Examples:
@@ -382,8 +382,7 @@ Details:
 * Each prefix may be used at most once.
 * You can give multiple keywords inside a single prefix by separating them with spaces.
   Example: `n/Susan Meier`
-* Parent name matching is case-insensitive and based on full words.
-* Parent phone and email matching are case-insensitive and based on partial text.
+* Parent name, phone, and email matching are case-insensitive and based on partial text.
 * Within a single field, multiple keywords behave as an `OR` search.
   Example: `n/Susan Meier` matches a parent name containing either `Susan` or `Meier`.
 * If you supply more than one field, the student must match **every supplied field**.

--- a/src/main/java/seedu/address/model/person/GuardianContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/GuardianContainsKeywordsPredicate.java
@@ -1,16 +1,16 @@
 package seedu.address.model.person;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Tests that a {@code Person}'s {@code Guardian} matches the given name, phone, and/or email keywords.
- * Name matching is case-insensitive full-word; phone and email matching is case-insensitive substring.
+ * Name matching, phone and email matching are case-insensitive substring.
  * A match in any supplied field is sufficient.
  */
 public class GuardianContainsKeywordsPredicate implements Predicate<Person> {
@@ -42,20 +42,32 @@ public class GuardianContainsKeywordsPredicate implements Predicate<Person> {
         boolean matchesAnyField = false;
 
         if (!nameKeywords.isEmpty()) {
+            String name = guardian.getName().fullName.toLowerCase(Locale.ROOT);
             matchesAnyField = matchesAnyField || nameKeywords.stream()
-                    .anyMatch(kw -> StringUtil.containsWordIgnoreCase(guardian.getName().fullName, kw));
+                    .map(String::trim)
+                    .filter(keyword -> !keyword.isEmpty())
+                    .map(keyword -> keyword.toLowerCase(Locale.ROOT))
+                    .anyMatch(name::contains);
         }
 
         if (!phoneKeywords.isEmpty()) {
             String phone = guardian.getPhone().map(p -> p.value).orElse("");
+            String lowerCasePhone = phone.toLowerCase(Locale.ROOT);
             matchesAnyField = matchesAnyField || phoneKeywords.stream()
-                    .anyMatch(kw -> phone.toLowerCase().contains(kw.toLowerCase()));
+                    .map(String::trim)
+                    .filter(keyword -> !keyword.isEmpty())
+                    .map(keyword -> keyword.toLowerCase(Locale.ROOT))
+                    .anyMatch(lowerCasePhone::contains);
         }
 
         if (!emailKeywords.isEmpty()) {
             String email = guardian.getEmail().map(e -> e.value).orElse("");
+            String lowerCaseEmail = email.toLowerCase(Locale.ROOT);
             matchesAnyField = matchesAnyField || emailKeywords.stream()
-                    .anyMatch(kw -> email.toLowerCase().contains(kw.toLowerCase()));
+                    .map(String::trim)
+                    .filter(keyword -> !keyword.isEmpty())
+                    .map(keyword -> keyword.toLowerCase(Locale.ROOT))
+                    .anyMatch(lowerCaseEmail::contains);
         }
 
         return hasFilters && matchesAnyField;

--- a/src/main/java/seedu/address/model/person/GuardianContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/GuardianContainsKeywordsPredicate.java
@@ -10,7 +10,7 @@ import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Tests that a {@code Person}'s {@code Guardian} matches the given name, phone, and/or email keywords.
- * Name matching, phone and email matching are case-insensitive substring.
+ * Name, phone and email matching are case-insensitive substring.
  * A match in any supplied field is sufficient.
  */
 public class GuardianContainsKeywordsPredicate implements Predicate<Person> {

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -1,13 +1,14 @@
 package seedu.address.model.person;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Name} contains any of the keywords given.
+ * Matching is case-insensitive and supports substring matching.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
@@ -18,8 +19,12 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        String lowerCaseName = person.getName().fullName.toLowerCase(Locale.ROOT);
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .map(String::trim)
+                .filter(keyword -> !keyword.isEmpty())
+                .map(keyword -> keyword.toLowerCase(Locale.ROOT))
+                .anyMatch(lowerCaseName::contains);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindParentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindParentCommandTest.java
@@ -140,6 +140,17 @@ public class FindParentCommandTest {
     }
 
     @Test
+    public void execute_matchByGuardianNamePartial_onePersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        GuardianContainsKeywordsPredicate predicate = makePredicate(
+                List.of("usa"), Collections.emptyList(), Collections.emptyList());
+        FindParentCommand command = new FindParentCommand(predicate);
+        expectedModel.updateFilteredPersonListWithAnd(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(BENSON), model.getFilteredPersonList());
+    }
+
+    @Test
     public void execute_matchByGuardianPhone_onePersonFound() {
         // Add a person with a guardian phone to a fresh model
         Person personWithParentPhone = getPersonBuilder("Test Student")

--- a/src/test/java/seedu/address/model/person/GuardianContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/GuardianContainsKeywordsPredicateTest.java
@@ -60,6 +60,9 @@ public class GuardianContainsKeywordsPredicateTest {
         GuardianContainsKeywordsPredicate namePredicate =
                 new GuardianContainsKeywordsPredicate(
                         List.of("Alice"), Collections.emptyList(), Collections.emptyList());
+        GuardianContainsKeywordsPredicate partialNamePredicate =
+                new GuardianContainsKeywordsPredicate(
+                        List.of("lic"), Collections.emptyList(), Collections.emptyList());
         GuardianContainsKeywordsPredicate phonePredicate =
                 new GuardianContainsKeywordsPredicate(
                         Collections.emptyList(), List.of("1234"), Collections.emptyList());
@@ -68,6 +71,7 @@ public class GuardianContainsKeywordsPredicateTest {
                         List.of("EXAMPLE.COM"));
 
         assertTrue(namePredicate.test(personWithGuardian));
+        assertTrue(partialNamePredicate.test(personWithGuardian));
         assertTrue(phonePredicate.test(personWithGuardian));
         assertTrue(emailPredicate.test(personWithGuardian));
     }

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -45,6 +45,10 @@ public class NameContainsKeywordsPredicateTest {
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
         assertTrue(predicate.test(getPersonBuilder("Alice Bob").build()));
 
+        // One partial keyword
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("lic"));
+        assertTrue(predicate.test(getPersonBuilder("Alice Bob").build()));
+
         // Multiple keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(getPersonBuilder("Alice Bob").build()));
@@ -55,6 +59,10 @@ public class NameContainsKeywordsPredicateTest {
 
         // Mixed-case keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        assertTrue(predicate.test(getPersonBuilder("Alice Bob").build()));
+
+        // Mixed-case partial keyword
+        predicate = new NameContainsKeywordsPredicate(Collections.singletonList("lIc"));
         assertTrue(predicate.test(getPersonBuilder("Alice Bob").build()));
     }
 


### PR DESCRIPTION
Add find substring behaviour for student and parent fields. Not many LoC changes needed and better to standardise across all find commands to use substring match except dates

Close #238 #251 